### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -111,11 +111,17 @@ DEPENDS= \
 	src/terminal/marshal.h \
 	src/trace/marshal.h
 
+DATE_FMT = +%Y%m%d
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
 CFLAGS= \
 	@CFLAGS@ \
 	-g \
 	-Isrc/include \
-	-DBUILD_DATE=`date +%Y%m%d` \
+	-DBUILD_DATE=$(BUILD_DATE) \
 	-DLOCALEDIR=$(localedir) \
 	@LIB3270_CFLAGS@ \
 	@GTK_CFLAGS@ \


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC to be independent of timezone.

This patch was done while working on reproducible builds for openSUSE.